### PR TITLE
Added --reconnect-on-close option (-x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Usage
 
 ```
 $ wscat -h
-usage: wscat [-h] [-v] [-l PORT] [-b] [-H HEADER] [-n] [-k] [-d] [-s SUBP] [address]
+usage: wscat [-h] [-v] [-l PORT] [-b] [-H HEADER] [-n] [-k] [-d] [-x DELAY] [-s SUBP] [address]
 
 Positional arguments:
   address
@@ -35,6 +35,9 @@ Optional arguments:
   -n, --no-check        Do not check for unauthorized certificates.
   -k, --keep-open       Do not close the socket after EOF.
   -d, --deflate         Use per-message deflate.
+  -x, --reconnect-on-close DELAY
+                        Retry the connection after DELAY milliseconds when
+                        a client socket conection fails.
   -s SUBP, --subprotocol SUBP
                         WebSocket subprotocol
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wscat2",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Unix-style WebSocket cat",
   "author": "Johan Nordberg",
   "license": "BSD-3-Clause",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ interface ICLIOptions {
     noCheck: boolean
     subProto?: string
     header: string[]
+    reconnectOnClose: number
 }
 
 const parser = new ArgumentParser({version, addHelp: true})
@@ -85,6 +86,13 @@ parser.addArgument(['-s', '--subprotocol'], {
     type: String,
 })
 
+parser.addArgument(['-x', '--reconnect-on-close'], {
+    dest: 'reconnectOnClose',
+    help: 'Reconnect to server after RECONNECT_MS milliseconds when connection closes.',
+    metavar: 'RECONNECT_MS',
+    type: Number,
+})
+
 parser.addArgument(['address'], {
     nargs: '?',
     type: String,
@@ -111,6 +119,7 @@ const options: any = {
     outputStream: process.stdout,
     perMessageDeflate: args.deflate,
     protocol: args.subProto,
+    reconnectOnClose: args.reconnectOnClose,
     rejectUnauthorized: !args.noCheck,
     reportClose: args.reportClose,
     sendResize: args.sendResize,

--- a/test/cli.sh
+++ b/test/cli.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function sha256() {
-    echo $(shasum -p -a 256 $1 | awk '{ print $1 }')
+    echo $(sha1sum $1 | awk '{ print $1 }')
 }
 
 test_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
This new option allows a web socket connecting as a client to keep re-attempting the connection until a server is available to listen. This is useful for situations where there is some never-ending process piping data to the web socket.